### PR TITLE
flutter_local_notifications_linux import issue fix

### DIFF
--- a/flutter_local_notifications/pubspec.yaml
+++ b/flutter_local_notifications/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     git:
       url: https://github.com/vagish1/flutter_local_notifications.git
       ref: master
-      path: flutter_local_notifications_platform_interface/
+      path: flutter_local_notifications_linux/
   flutter_local_notifications_platform_interface:
     git:
       url: https://github.com/vagish1/flutter_local_notifications.git


### PR DESCRIPTION
As this repository hosts multiple packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). Should the PR more than one package than please prefix the title of the PR with [various] The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
